### PR TITLE
Add rackets/controllers checkbox and sort bookings by date

### DIFF
--- a/src/components/StartModal.jsx
+++ b/src/components/StartModal.jsx
@@ -7,9 +7,11 @@ const StartModal = ({ table, isOpen, onClose, onStart }) => {
   const isFoosOrHockey = table?.gameType === 'foosball' || table?.gameType === 'airhockey';
   const isPlayStation = table?.gameType === "playstation";
   const isCustomTimer = table?.gameType === "custom";
+  const isPingPong = table?.gameType === "pingpong";
   const [mode, setMode] = useState("countdown"); // 'standard' or 'countdown'
   const [durationMinutes, setDurationMinutes] = useState(60);
   const [fitPass, setFitPass] = useState(false);
+  const [extraEquipment, setExtraEquipment] = useState(false);
   const [customName, setCustomName] = useState("");
   const [customHourlyRate, setCustomHourlyRate] = useState("");
   const [validationError, setValidationError] = useState("");
@@ -19,6 +21,7 @@ const StartModal = ({ table, isOpen, onClose, onStart }) => {
     setMode("countdown");
     setDurationMinutes(60);
     setFitPass(false);
+    setExtraEquipment(false);
     setCustomName(isCustomTimer ? (table.name === "Blank Timer" ? "" : table.name || "") : table.name || "");
     setCustomHourlyRate(
       typeof table.hourlyRate === "number" && table.hourlyRate > 0
@@ -59,6 +62,7 @@ const StartModal = ({ table, isOpen, onClose, onStart }) => {
       mode === "countdown" ? parseInt(durationMinutes, 10) : null,
       {
         fitPass: isFoosOrHockey || isPlayStation || isCustomTimer ? false : fitPass,
+        extraEquipment: (isPingPong || isPlayStation) ? extraEquipment : false,
         ...customOptions,
       }
     );
@@ -76,6 +80,7 @@ const StartModal = ({ table, isOpen, onClose, onStart }) => {
           durationMinutes={durationMinutes}
           setDurationMinutes={setDurationMinutes}
           isPlayStation={isPlayStation}
+          isPingPong={isPingPong}
           isCustomTimer={isCustomTimer}
           customName={customName}
           setCustomName={setCustomName}
@@ -84,6 +89,8 @@ const StartModal = ({ table, isOpen, onClose, onStart }) => {
           isFoosOrHockey={isFoosOrHockey}
           fitPass={fitPass}
           setFitPass={setFitPass}
+          extraEquipment={extraEquipment}
+          setExtraEquipment={setExtraEquipment}
           validationError={validationError}
         />
 

--- a/src/components/bookings/BookingList.jsx
+++ b/src/components/bookings/BookingList.jsx
@@ -13,7 +13,9 @@ export default function BookingList({ bookings, isLoading, onMarkDone, onDelete 
       {!isLoading && bookings.length === 0 && (
         <p className="booking-empty">No bookings yet.</p>
       )}
-      {bookings.map((booking) => (
+      {[...bookings]
+        .sort((a, b) => new Date(a.booking_at || a.created_at) - new Date(b.booking_at || b.created_at))
+        .map((booking) => (
         <div className="booking-row" key={booking.id}>
           <div className="booking-name">{booking.customer_name}</div>
           <div className="booking-meta">
@@ -21,7 +23,7 @@ export default function BookingList({ bookings, isLoading, onMarkDone, onDelete 
             {booking.hours_count ? ` • ${booking.hours_count} hour(s)` : ""}
           </div>
           <div className="booking-time">
-            {new Date(booking.booking_at || booking.created_at).toLocaleString()}
+            <strong>{new Date(booking.booking_at || booking.created_at).toLocaleString()}</strong>
           </div>
           <div className="booking-actions">
             <button

--- a/src/components/start-modal/StartModalContentFields.jsx
+++ b/src/components/start-modal/StartModalContentFields.jsx
@@ -7,6 +7,7 @@ export default function StartModalContentFields({
   durationMinutes,
   setDurationMinutes,
   isPlayStation,
+  isPingPong,
   isCustomTimer,
   customName,
   setCustomName,
@@ -15,6 +16,8 @@ export default function StartModalContentFields({
   isFoosOrHockey,
   fitPass,
   setFitPass,
+  extraEquipment,
+  setExtraEquipment,
   validationError,
 }) {
   return (
@@ -55,8 +58,32 @@ export default function StartModalContentFields({
         </div>
       )}
       {isPlayStation && (
-        <div className="duration-input" style={{ marginTop: 8, opacity: 0.9 }}>
-          Pricing: 20 GEL per hour
+        <>
+          <div className="duration-input" style={{ marginTop: 8, opacity: 0.9 }}>
+            Pricing: {extraEquipment ? 25 : 20} GEL per hour
+          </div>
+          <div style={{ marginTop: 12 }}>
+            <label>
+              <input
+                type="checkbox"
+                checked={extraEquipment}
+                onChange={(e) => setExtraEquipment(e.target.checked)}
+              />
+              &nbsp;+2 Controllers (+5 GEL/hour)
+            </label>
+          </div>
+        </>
+      )}
+      {isPingPong && (
+        <div style={{ marginTop: 12 }}>
+          <label>
+            <input
+              type="checkbox"
+              checked={extraEquipment}
+              onChange={(e) => setExtraEquipment(e.target.checked)}
+            />
+            &nbsp;+2 Rackets (+5 GEL/hour)
+          </label>
         </div>
       )}
       {isCustomTimer && (

--- a/src/hooks/useTables.js
+++ b/src/hooks/useTables.js
@@ -64,6 +64,7 @@ export default function useTables() {
                 sessionStartTime: Date.now(),
                 sessionEndTime: null,
                 fitPass: !!options.fitPass,
+                extraEquipment: !!options.extraEquipment,
               };
             } else {
               // Standard mode
@@ -79,6 +80,7 @@ export default function useTables() {
                 sessionStartTime: table.sessionStartTime ?? Date.now(),
                 sessionEndTime: null,
                 fitPass: !!options.fitPass,
+                extraEquipment: !!options.extraEquipment,
               };
             }
           }

--- a/src/utils/tableCardView.js
+++ b/src/utils/tableCardView.js
@@ -22,7 +22,9 @@ export function getTableCardViewModel(table, hourlyRate, sales) {
     fitPass,
     gameType,
     hourlyRate: customHourlyRate,
+    extraEquipment,
   } = table;
+  const equipmentBonus = extraEquipment ? 5 : 0;
 
   let displayTimeSeconds = 0;
   let currentCost = "0.00";
@@ -46,7 +48,7 @@ export function getTableCardViewModel(table, hourlyRate, sales) {
       const ratePerSecond = 6 / (30 * 60);
       sessionCost = ((initialCountdownSeconds || 0) * ratePerSecond).toFixed(2);
     } else if (hasCustomRate) {
-      const ratePerSecond = customHourlyRate / 3600;
+      const ratePerSecond = (customHourlyRate + equipmentBonus) / 3600;
       sessionCost = ((initialCountdownSeconds || 0) * ratePerSecond).toFixed(2);
     } else {
       const startMs = sessionStartTime || Date.now();
@@ -54,10 +56,10 @@ export function getTableCardViewModel(table, hourlyRate, sales) {
       sessionCost = calculateSegmentedPrice({
         startTimeMs: startMs,
         endTimeMs: endMs,
-        hourlyRate,
+        hourlyRate: hourlyRate + equipmentBonus,
         saleFromHour: sales.saleFromHour,
         saleToHour: sales.saleToHour,
-        saleHourlyRate: sales.saleHourlyRate,
+        saleHourlyRate: sales.saleHourlyRate + equipmentBonus,
       });
     }
     currentCost = sessionCost;
@@ -74,7 +76,7 @@ export function getTableCardViewModel(table, hourlyRate, sales) {
       const ratePerSecond = 6 / (30 * 60);
       currentCost = (displayTimeSeconds * ratePerSecond).toFixed(2);
     } else if (hasCustomRate) {
-      const ratePerSecond = customHourlyRate / 3600;
+      const ratePerSecond = (customHourlyRate + equipmentBonus) / 3600;
       currentCost = (displayTimeSeconds * ratePerSecond).toFixed(2);
     } else {
       const startMs = sessionStartTime || Date.now() - displayTimeSeconds * 1000;
@@ -82,10 +84,10 @@ export function getTableCardViewModel(table, hourlyRate, sales) {
       currentCost = calculateSegmentedPrice({
         startTimeMs: startMs,
         endTimeMs: endMs,
-        hourlyRate,
+        hourlyRate: hourlyRate + equipmentBonus,
         saleFromHour: sales.saleFromHour,
         saleToHour: sales.saleToHour,
-        saleHourlyRate: sales.saleHourlyRate,
+        saleHourlyRate: sales.saleHourlyRate + equipmentBonus,
       });
     }
     sessionCost = currentCost;


### PR DESCRIPTION
- Sort bookings by date ascending (nearest first) and bold the date text
- Add "+2 Rackets (+5 GEL/hour)" checkbox to ping-pong table start modal
- Add "+2 Controllers (+5 GEL/hour)" checkbox to PlayStation start modal
- Apply +5 GEL/hour equipment bonus to pricing calculations (preserves sale pricing for ping-pong)
- extraEquipment flag lives in local state only, not synced to DB